### PR TITLE
druid :: Adds support for extracting referrer domain

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/AvroParsers.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/AvroParsers.java
@@ -20,12 +20,15 @@
 package io.druid.data.input.avro;
 
 import io.druid.data.input.InputRow;
+import io.druid.data.input.avro.processor.utils.DelegatingMap;
 import io.druid.data.input.impl.MapInputRowParser;
 import io.druid.data.input.impl.ParseSpec;
 import io.druid.java.util.common.parsers.JSONPathSpec;
 import io.druid.java.util.common.parsers.ObjectFlattener;
 import io.druid.java.util.common.parsers.ObjectFlatteners;
 import org.apache.avro.generic.GenericRecord;
+
+import io.druid.data.input.avro.processor.MessageProcessor;
 
 public class AvroParsers
 {
@@ -56,6 +59,12 @@ public class AvroParsers
       ObjectFlattener<GenericRecord> avroFlattener
   )
   {
-    return new MapInputRowParser(parseSpec).parse(avroFlattener.flatten(record));
+    return new MapInputRowParser(parseSpec).parse(
+        MessageProcessor.process(
+            new DelegatingMap<>(
+                avroFlattener.flatten(record)
+            )
+        )
+    );
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
@@ -6,21 +6,17 @@ import java.util.Map;
 
 public class MessageProcessor
 {
+  private static RegExMapper referrerMapper = new RegExMapper(
+      "referrer_domain",
+      "([a-z0-9|-]+\\.)*[a-z0-9|-]+\\.[a-z]+"
+  );
+
   public static Map process(Map<String, Object> map) {
 
     //Temporary hack for referrer domain stripping
     //until we have a proper ETL in Druid.
     if( map.containsKey("referrer_domain") ) {
-
-      RegExMapper referrerMapper = new RegExMapper(
-          "referrer_domain",
-          "([a-z0-9|-]+\\.)*[a-z0-9|-]+\\.[a-z]+"
-      );
-
-
-
-
-      map = referrerMapper.map(map);
+        map = referrerMapper.map(map);
     }
 
     return map;

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
@@ -1,0 +1,28 @@
+package io.druid.data.input.avro.processor;
+
+import io.druid.data.input.avro.processor.mappers.RegExMapper;
+
+import java.util.Map;
+
+public class MessageProcessor
+{
+  public static Map process(Map<String, Object> map) {
+
+    //Temporary hack for referrer domain stripping
+    //until we have a proper ETL in Druid.
+    if( map.containsKey("referrer_domain") ) {
+
+      RegExMapper referrerMapper = new RegExMapper(
+          "referrer_domain",
+          ".*//([^/]+)/"
+      );
+
+
+
+
+      map = referrerMapper.map(map);
+    }
+
+    return map;
+  }
+}

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
@@ -14,7 +14,7 @@ public class MessageProcessor
 
       RegExMapper referrerMapper = new RegExMapper(
           "referrer_domain",
-          ".*//([^/]+)/"
+          "([a-z0-9|-]+\\.)*[a-z0-9|-]+\\.[a-z]+"
       );
 
 

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/MessageProcessor.java
@@ -15,7 +15,7 @@ public class MessageProcessor
 
     //Temporary hack for referrer domain stripping
     //until we have a proper ETL in Druid.
-    if( map.containsKey("referrer_domain") ) {
+    if( referrerMapper.canMap(map) ) {
         map = referrerMapper.map(map);
     }
 

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/IMapper.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/IMapper.java
@@ -1,0 +1,30 @@
+
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.data.input.avro.processor.mappers;
+
+import java.util.Map;
+
+/**
+ *
+ */
+public interface IMapper
+{
+  Map<String,Object> map(Map<String,Object> map);
+}

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/IMapper.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/IMapper.java
@@ -26,5 +26,6 @@ import java.util.Map;
  */
 public interface IMapper
 {
+  boolean canMap(Map<String,Object> map);
   Map<String,Object> map(Map<String,Object> map);
 }

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/RegExMapper.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/RegExMapper.java
@@ -38,6 +38,12 @@ public class RegExMapper implements IMapper
     this.field = field;
   }
 
+  @Override
+  public boolean canMap(Map<String,Object> map) {
+    return map.containsKey(this.field);
+  }
+
+  @Override
   public Map<String,Object> map(Map<String,Object> map)
   {
     Object value = map.get(field);

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/RegExMapper.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/mappers/RegExMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.data.input.avro.processor.mappers;
+
+
+import io.druid.data.input.avro.processor.mappers.IMapper;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.Map;
+
+/**
+ *
+ */
+public class RegExMapper implements IMapper
+{
+  private final String  field;
+  private final Pattern pattern;
+
+  public RegExMapper(String field, String regEx) {
+    this.pattern = Pattern.compile(regEx);
+    this.field = field;
+  }
+
+  public Map<String,Object> map(Map<String,Object> map)
+  {
+    Object value = map.get(field);
+
+    if(value != null) {
+
+      Matcher m = pattern.matcher(value.toString());
+
+      if( m.find() ) {
+
+        map.put(field, m.group(0));
+      }
+
+    }
+
+    return map;
+  }
+}

--- a/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/utils/DelegatingMap.java
+++ b/extensions-core/avro-extensions/src/main/java/io/druid/data/input/avro/processor/utils/DelegatingMap.java
@@ -1,0 +1,48 @@
+package io.druid.data.input.avro.processor.utils;
+
+import com.google.common.collect.ForwardingMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by pcunningham on 14/11/2017.
+ */
+public class DelegatingMap<K, V> extends ForwardingMap<K, V>{
+
+    private Map<K, V> data;
+    private Map<K, V> delegate;
+
+    public DelegatingMap(Map<K,V> delegate) {
+      this.data = new HashMap<K,V>();
+      this.delegate = delegate;
+    }
+
+    public DelegatingMap(Map<K,V> delegate, K key, V value) {
+
+      this(delegate);
+
+      this.data.put(key,value);
+    }
+
+    @Override
+    protected Map<K,V> delegate() {
+      return this.delegate;
+    }
+
+    @Override
+    public V get(Object key)
+    {
+      if( this.data.containsKey(key) ) {
+
+        return data.get(key);
+      }
+
+      return this.delegate().get(key);
+    }
+
+    @Override
+    public V put(K key, V value)
+    {
+      return data.put(key, value);
+    }
+}


### PR DESCRIPTION
Extracts domain from referrer field for audience sync.

Only works when dimension name is referrer_domain and
uses   "([a-z0-9|-]+\\.)*[a-z0-9|-]+\\.[a-z]+" as the extraction regex.