### PR TITLE
Reduce default logging level

### DIFF
--- a/common/src/main/resources/log4j2.xml
+++ b/common/src/main/resources/log4j2.xml
@@ -23,7 +23,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="info">
+    <Root level="warn">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
- The druid-commons jar is included in hadoop jobs and hence the
  log4j2.xml within here defines the logging level.
- To prevent an excessive number of messages change the logging level to
  warn.

Tried a bajillion other things to change the logging level but this is the only thing that seems to work.