### PR TITLE
Changing influxdb emitter to use https

### DIFF
--- a/extensions-spotx/influxdb-emitter/pom.xml
+++ b/extensions-spotx/influxdb-emitter/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>io.druid</groupId>


### PR DESCRIPTION
See https://jira.spotxchange.com/browse/DRUID-223

- certificate must be added to default truststore (java_home/lib/security/cacerts)
    - `keytool -import -file influx-data.pem -alias influx_lod -keystore cacerts` default password is changeit.

